### PR TITLE
Expansion fix

### DIFF
--- a/srcs/environment_variables/environment_variables.c
+++ b/srcs/environment_variables/environment_variables.c
@@ -1,6 +1,8 @@
 #include "environment_variables.h"
 #include "../tokenizer/tokenizer.h"
 
+//int   is_under_brackets
+
 bool    is_variable(char *token_string, int i)
 {
     if (token_string[i] != EXPANSION_VARS)

--- a/srcs/tokenizer/expand.c
+++ b/srcs/tokenizer/expand.c
@@ -55,7 +55,7 @@ char    *token_expanded_create(char *token_string, char **envp)
         quoted_text_check(token_string[iter.i], &is_double_quoted, DQUOTE_LITERAL);
         if (token_string[iter.i] == SQUOTE_LITERAL && is_double_quoted == -1)
             single_quotation_skip(buffer, token_string, &iter);
-        if (is_variable(token_string, iter.i) == true)
+        else if (is_variable(token_string, iter.i) == true)
             expansion_vars_handle(buffer, token_string, &iter, envp);
         else
             buffer_fill(buffer, token_string, &iter);


### PR DESCRIPTION
1. Fixed a minor detail on expansion (on the same token, after single quotes were closed, no variable would expanded, even if they were only under double quotes)
2. Even though i started trying to apply the code for variables between square brackets, i dropped it and decided to not add that feature.